### PR TITLE
Add flag to disable label/prefix in output

### DIFF
--- a/cmd/proc.go
+++ b/cmd/proc.go
@@ -15,7 +15,6 @@ var envFile string
 var noEnvFile bool
 var procfile string
 var omitEnv bool
-var noLabel bool // Add noLabel flag
 
 var procCommand = cobra.Command{
 	Use:     "proc",
@@ -65,12 +64,12 @@ var procCommand = cobra.Command{
 
 		for label, command := range procfileMap {
 			commandStrings = append(commandStrings, command)
-			if !noLabel { // Conditionally append label if noLabel is false
+			if !noLabel {
 				commandLabels = append(commandLabels, label)
 			}
 		}
 
-		if !noLabel { // Conditionally process labels if noLabel is false
+		if !noLabel {
 			var maxLabelLen int
 
 			for _, label := range commandLabels {
@@ -116,6 +115,6 @@ func init() {
 	procCommand.Flags().StringVarP(&envFile, "env-file", "e", ".env", "Path to the env file")
 	procCommand.Flags().BoolVar(&omitEnv, "omit-env", false, "Omit any existing runtime environment variables")
 	procCommand.Flags().BoolVarP(&noEnvFile, "no-env-file", "E", false, "Don't load the env file")
-	procCommand.Flags().BoolVarP(&noLabel, "no-label", "B", false, "do not attach label/prefix to output") // Add noLabel flag
+	procCommand.Flags().BoolVarP(&noLabel, "no-label", "B", false, "do not attach label/prefix to output")
 	rootCmd.AddCommand(&procCommand)
 }

--- a/cmd/proc.go
+++ b/cmd/proc.go
@@ -64,7 +64,9 @@ var procCommand = cobra.Command{
 
 		for label, command := range procfileMap {
 			commandStrings = append(commandStrings, command)
-			if !noLabel {
+			if noLabel {
+				commandLabels = append(commandLabels, "")
+			} else {
 				commandLabels = append(commandLabels, label)
 			}
 		}

--- a/cmd/proc.go
+++ b/cmd/proc.go
@@ -15,6 +15,7 @@ var envFile string
 var noEnvFile bool
 var procfile string
 var omitEnv bool
+var noLabel bool // Add noLabel flag
 
 var procCommand = cobra.Command{
 	Use:     "proc",
@@ -64,19 +65,23 @@ var procCommand = cobra.Command{
 
 		for label, command := range procfileMap {
 			commandStrings = append(commandStrings, command)
-			commandLabels = append(commandLabels, label)
-		}
-
-		var maxLabelLen int
-
-		for _, label := range commandLabels {
-			if len(label) > maxLabelLen {
-				maxLabelLen = len(label)
+			if !noLabel { // Conditionally append label if noLabel is false
+				commandLabels = append(commandLabels, label)
 			}
 		}
 
-		for i, label := range commandLabels {
-			commandLabels[i] = fmt.Sprintf("%s%s", label, strings.Repeat(" ", maxLabelLen-len(label)))
+		if !noLabel { // Conditionally process labels if noLabel is false
+			var maxLabelLen int
+
+			for _, label := range commandLabels {
+				if len(label) > maxLabelLen {
+					maxLabelLen = len(label)
+				}
+			}
+
+			for i, label := range commandLabels {
+				commandLabels[i] = fmt.Sprintf("%s%s", label, strings.Repeat(" ", maxLabelLen-len(label)))
+			}
 		}
 
 		commands, err := konk.RunConcurrently(cmd.Context(), konk.RunConcurrentlyConfig{
@@ -111,5 +116,6 @@ func init() {
 	procCommand.Flags().StringVarP(&envFile, "env-file", "e", ".env", "Path to the env file")
 	procCommand.Flags().BoolVar(&omitEnv, "omit-env", false, "Omit any existing runtime environment variables")
 	procCommand.Flags().BoolVarP(&noEnvFile, "no-env-file", "E", false, "Don't load the env file")
+	procCommand.Flags().BoolVarP(&noLabel, "no-label", "B", false, "do not attach label/prefix to output") // Add noLabel flag
 	rootCmd.AddCommand(&procCommand)
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -13,6 +13,7 @@ var continueOnError bool
 var noShell bool
 var workingDirectory string
 var noColor bool
+var noLabel bool
 
 var Version = "dev"
 

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -15,7 +15,6 @@ import (
 var cmdAsLabel bool
 var npmCmds []string
 var names []string
-var noLabel bool // Add noLabel flag
 
 var runCommand = cobra.Command{
 	Use:     "run <subcommand>",
@@ -37,7 +36,7 @@ func init() {
 	runCommand.PersistentFlags().BoolVarP(&cmdAsLabel, "command-as-label", "L", false, "use each command as its own label")
 	runCommand.PersistentFlags().StringArrayVarP(&npmCmds, "npm", "n", []string{}, "npm command")
 	runCommand.PersistentFlags().StringArrayVarP(&names, "label", "l", []string{}, "label prefix for the command")
-	runCommand.PersistentFlags().BoolVarP(&noLabel, "no-label", "B", false, "do not attach label/prefix to output") // Add noLabel flag
+	runCommand.PersistentFlags().BoolVarP(&noLabel, "no-label", "B", false, "do not attach label/prefix to output")
 	rootCmd.AddCommand(&runCommand)
 }
 
@@ -95,7 +94,7 @@ func collectCommands(args []string) ([]string, []string, error) {
 }
 
 func collectLabels(commandStrings []string) []string {
-	if noLabel { // Check if noLabel is true to return empty labels
+	if noLabel {
 		return make([]string, len(commandStrings))
 	}
 

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -15,6 +15,7 @@ import (
 var cmdAsLabel bool
 var npmCmds []string
 var names []string
+var noLabel bool // Add noLabel flag
 
 var runCommand = cobra.Command{
 	Use:     "run <subcommand>",
@@ -36,6 +37,7 @@ func init() {
 	runCommand.PersistentFlags().BoolVarP(&cmdAsLabel, "command-as-label", "L", false, "use each command as its own label")
 	runCommand.PersistentFlags().StringArrayVarP(&npmCmds, "npm", "n", []string{}, "npm command")
 	runCommand.PersistentFlags().StringArrayVarP(&names, "label", "l", []string{}, "label prefix for the command")
+	runCommand.PersistentFlags().BoolVarP(&noLabel, "no-label", "B", false, "do not attach label/prefix to output") // Add noLabel flag
 	rootCmd.AddCommand(&runCommand)
 }
 
@@ -93,6 +95,10 @@ func collectCommands(args []string) ([]string, []string, error) {
 }
 
 func collectLabels(commandStrings []string) []string {
+	if noLabel { // Check if noLabel is true to return empty labels
+		return make([]string, len(commandStrings))
+	}
+
 	labels := make([]string, len(commandStrings))
 
 	for i, cmdStr := range commandStrings {

--- a/integration/proc_test.go
+++ b/integration/proc_test.go
@@ -62,6 +62,19 @@ func TestProcWithExternalEnvAndEnv(t *testing.T) {
 `, sortOut(t, out), "output did not match expected output")
 }
 
+func TestProcNoLabel(t *testing.T) {
+	t.Parallel()
+
+	out, err := newProcRunner().
+		withFlags("-B").
+		run(t)
+	require.NoError(t, err)
+
+	assert.Equal(t, `a
+b
+`, sortOut(t, out), "output did not match expected output")
+}
+
 func newProcRunner() runner {
 	return newRunner("proc").withFlags("-w", "fixtures/proc")
 }

--- a/integration/run_c_test.go
+++ b/integration/run_c_test.go
@@ -115,6 +115,22 @@ func TestRunConcurrentlyWithNpmGlob(t *testing.T) {
 `, sortOut(t, out), "output did not match expected output")
 }
 
+func TestRunConcurrentlyNoLabel(t *testing.T) {
+	t.Parallel()
+
+	out, err := newGroupedConcurrentRunner().
+		withFlags(
+			"-B",
+			"echo a", "echo b", "echo c").
+		run(t)
+	require.NoError(t, err)
+
+	assert.Equal(t, `a
+b
+c
+`, sortOut(t, out), "output did not match expected output")
+}
+
 func newGroupedConcurrentRunner() runner {
 	return newRunner("run").withFlags("concurrently", "-g")
 }

--- a/integration/run_s_test.go
+++ b/integration/run_s_test.go
@@ -116,6 +116,18 @@ func TestRunSeriallyWithNpmGlob(t *testing.T) {
 `, out, "output did not match expected output")
 }
 
+func TestRunSeriallyNoLabel(t *testing.T) {
+	t.Parallel()
+
+	out, err := newSerialRunner().withFlags("-B", "echo a", "echo b", "echo c").run(t)
+	require.NoError(t, err)
+
+	assert.Equal(t, `a
+b
+c
+`, out, "output did not match expected output")
+}
+
 func newSerialRunner() runner {
 	return newRunner("run").withFlags("serially")
 }

--- a/konk/command.go
+++ b/konk/command.go
@@ -111,7 +111,7 @@ func (c *Command) Run(ctx context.Context, cancel context.CancelFunc, conf RunCo
 		for {
 			select {
 			case t := <-out:
-				line := fmt.Sprintf("%s %s\n", c.prefix, t)
+				line := fmt.Sprintf("%s%s\n", c.prefix, t)
 
 				if conf.AggregateOutput {
 					c.out.WriteString(line)
@@ -183,6 +183,10 @@ func newExitError(label string, err error) error {
 }
 
 func getPrefix(label string, noColor bool) string {
+	if label == "" {
+		return ""
+	}
+
 	var prefix string
 
 	if noColor {
@@ -193,5 +197,5 @@ func getPrefix(label string, noColor bool) string {
 		prefix = prefixStyle.Render(fmt.Sprintf("[%s]", label))
 	}
 
-	return prefix
+	return prefix + " "
 }


### PR DESCRIPTION
Introduces a new `--no-label` flag to suppress label/prefix attachment in command outputs.

- **Flag Addition**: Implements the `--no-label` flag with shorthand `-B` across `cmd/proc.go`, `cmd/run.go`, and updates the flag parsing logic to conditionally suppress labels in command outputs.
- **Label Handling**: Modifies label generation and attachment logic in `cmd/proc.go` and `cmd/run.go` to conditionally skip label attachment based on the `noLabel` flag's value. This includes changes to `collectLabels` function in `cmd/run.go` to return empty labels if `noLabel` is true.
- **Prefix Management**: Updates `konk/command.go` to adjust the `getPrefix` function, ensuring an empty string is returned if the label is empty, which aligns with the `noLabel` flag's purpose. Also, modifies the output formatting to remove the space between the prefix and the line when the prefix is empty.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/jclem/konk?shareId=acfc8c8a-4c47-4d91-b4c4-912d4a2c2806).